### PR TITLE
JIP fix

### DIFF
--- a/f/radios/tfr/tfr_settings.sqf
+++ b/f/radios/tfr/tfr_settings.sqf
@@ -20,11 +20,11 @@ f_radios_settings_tfr_disableRadios = FALSE;
 // Which units should be given LR backpacks
 // TRUE = all group leaders get backpacks
 // FALSE = only units defined in next variable will get LR backpacks
-f_radios_settings_tfr_defaultLRBackpacks = TRUE;
+f_radios_settings_tfr_defaultLRBackpacks = FALSE;
 
 // Unit types you want to give long-range radios if previous is
 // E.G: ["co", "m"] would give the CO and all medics 2 long-range radios
-f_radios_settings_tfr_backpackRadios = ["co","dc"];
+f_radios_settings_tfr_backpackRadios = ["co","dc","ftl","vc","pp"];
 
 // Independent radio encryption code: Independent faction use radio code of side 
 // they are friendly to if they are only friendly to one side.


### PR DESCRIPTION
Te zmiany powinny wystarczyć by naprawić problem z slotami JIP, które dostają aktualnie długie radia niezalezienie od wybranej klasy.