### PR TITLE
Poprawki do update pazdziernik

### DIFF
--- a/Szblon_misji.Altis/description.ext
+++ b/Szblon_misji.Altis/description.ext
@@ -33,11 +33,11 @@ enableDebugConsole = 1;
 // F3 - Respawn Settings
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-respawn = 3; // respawn w bazie
-respawndelay = 10; // 10 sekund po smierci dopiero sie zrespawnuje gracz
+respawn = 3; // respawn w bazie ( Na PvP zmienić na respawn = 1 )
+respawndelay = 5; // 5s Oczekiwanie na resp
 respawnOnStart = 0; // nie tykac
-respawnTemplates[] = {"Seagull","f_spectator","f_JIP"}; // nie tykac
-// respawnTemplates[] = {"Seagull","f_SpectatorRespawn"}; // spectator z opcją respawnu ( używać tylko gdy respawn=3 )
+//respawnTemplates[] = {"Seagull","f_spectator","f_JIP"}; // Tryb obserwatora na PvP
+respawnTemplates[] = {"Seagull","f_SpectatorRespawn"}; // Spectator z opcją respawnu ( używać tylko gdy respawn=3 )
 
 // ============================================================================================
 

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie MSV (opfor)/f_assignGear_csat.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie MSV (opfor)/f_assignGear_csat.sqf
@@ -134,8 +134,9 @@ _pistolmag = "rhs_mag_9x18_12_57N181S";
 // Granaty ręczne
 _grenade = "rhs_mag_rgd5";
 _smokegrenade = "SmokeShell";
-_smokegrenadegreen = "rhs_mag_rdg2_black";
-_smokegrenadered = "rhs_mag_nspn_red";
+_smokegrenadegreen = "SmokeShellGreen";
+_smokegrenadered = "SmokeShellRed";
+_smokegrenadeblue = "SmokeShellBlue";
 
 // Sprzet medyczny
 _personalAidKit = "ACE_personalAidKit";		// Zestaw pierwszej pomocy

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie MSV (opfor)/f_assignGear_csat.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie MSV (opfor)/f_assignGear_csat.sqf
@@ -413,7 +413,7 @@ switch (_typeofUnit) do
 		_unit addweapon _pistol;
 		_unit addmagazines [_grenade,1];
 		_unit addmagazines [_smokegrenade,1];
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -430,7 +430,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
 		_unit addmagazines [_grenade,1];
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -463,7 +463,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_grenade,1];
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["g"] call _backpack;
@@ -951,7 +951,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 1];
 		_unit addMagazineCargoGlobal [_grenade, 4];
 		_unit addMagazineCargoGlobal [_smokegrenade, 4];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addMagazineCargoGlobal [_glmag, 4];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,4];
@@ -973,7 +973,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 12];
 		_unit addmagazineCargoGlobal [_mgrenade,12];
 		_unit addMagazineCargoGlobal [_smokegrenade, 12];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 4];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 4];
 		_unit addMagazineCargoGlobal [_glmag, 12];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 12];
 		_unit addItemCargoGlobal [_firstaid,8];
@@ -995,7 +995,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addmagazineCargoGlobal [_mgrenade,8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addMagazineCargoGlobal [_glmag, 8];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,6];
@@ -1018,7 +1018,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 2];
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addItemCargoGlobal [_firstaid, 6];
 };
 
@@ -1039,7 +1039,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 6];
 		_unit addMagazineCargoGlobal [_grenade, 25];
 		_unit addMagazineCargoGlobal [_smokegrenade, 25];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 6];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 6];
 		_unit addItemCargoGlobal [_firstaid, 25];
 };
 
@@ -1060,7 +1060,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 20];
 		_unit addMagazineCargoGlobal [_grenade, 75];
 		_unit addMagazineCargoGlobal [_smokegrenade, 75];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 20];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 20];
 		_unit addItemCargoGlobal [_firstaid, 75];
 };
 

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie VDV desert (opfor)/f_assignGear_csat.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie VDV desert (opfor)/f_assignGear_csat.sqf
@@ -411,7 +411,7 @@ switch (_typeofUnit) do
 		_unit addweapon _pistol;
 		_unit addmagazines [_grenade,1];
 		_unit addmagazines [_smokegrenade,1];
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -428,7 +428,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
 		_unit addmagazines [_grenade,1];
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -461,7 +461,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_grenade,1];
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadered,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["g"] call _backpack;
@@ -950,7 +950,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 1];
 		_unit addMagazineCargoGlobal [_grenade, 4];
 		_unit addMagazineCargoGlobal [_smokegrenade, 4];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addMagazineCargoGlobal [_glmag, 4];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,4];
@@ -972,7 +972,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 12];
 		_unit addmagazineCargoGlobal [_mgrenade,12];
 		_unit addMagazineCargoGlobal [_smokegrenade, 12];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 4];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 4];
 		_unit addMagazineCargoGlobal [_glmag, 12];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 12];
 		_unit addItemCargoGlobal [_firstaid,8];
@@ -994,7 +994,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addmagazineCargoGlobal [_mgrenade,8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addMagazineCargoGlobal [_glmag, 8];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,6];
@@ -1017,7 +1017,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 2];
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 2];
 		_unit addItemCargoGlobal [_firstaid, 6];
 };
 
@@ -1038,7 +1038,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 6];
 		_unit addMagazineCargoGlobal [_grenade, 25];
 		_unit addMagazineCargoGlobal [_smokegrenade, 25];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 6];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 6];
 		_unit addItemCargoGlobal [_firstaid, 25];
 };
 
@@ -1059,7 +1059,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 20];
 		_unit addMagazineCargoGlobal [_grenade, 75];
 		_unit addMagazineCargoGlobal [_smokegrenade, 75];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 20];
+		_unit addMagazineCargoGlobal [_smokegrenadered, 20];
 		_unit addItemCargoGlobal [_firstaid, 75];
 };
 

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie VDV desert (opfor)/f_assignGear_csat.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Rosyjskie VDV desert (opfor)/f_assignGear_csat.sqf
@@ -134,8 +134,9 @@ _pistolmag = "rhs_mag_9x18_12_57N181S";
 // Granaty ręczne
 _grenade = "rhs_mag_rgd5";
 _smokegrenade = "SmokeShell";
-_smokegrenadegreen = "rhs_mag_rdg2_black";
-_smokegrenadered = "rhs_mag_nspn_red";
+_smokegrenadegreen = "SmokeShellGreen";
+_smokegrenadered = "SmokeShellRed";
+_smokegrenadeblue = "SmokeShellBlue";
 
 // Sprzet medyczny
 _personalAidKit = "ACE_personalAidKit";		// Zestaw pierwszej pomocy

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Ultranationalist (indfor)/f_assignGear_aaf.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Ultranationalist (indfor)/f_assignGear_aaf.sqf
@@ -134,8 +134,9 @@ _pistolmag = "rhs_mag_9x18_12_57N181S";
 // Granaty ręczne
 _grenade = "rhs_mag_rgd5";
 _smokegrenade = "SmokeShell";
-_smokegrenadegreen = "rhs_mag_rdg2_black";
-_smokegrenadered = "rhs_mag_nspn_red";
+_smokegrenadegreen = "SmokeShellGreen";
+_smokegrenadered = "SmokeShellRed";
+_smokegrenadeblue = "SmokeShellBlue";
 
 // Sprzet medyczny
 _personalAidKit = "ACE_personalAidKit";		// Zestaw pierwszej pomocy

--- a/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Ultranationalist (indfor)/f_assignGear_aaf.sqf
+++ b/Szblon_misji.Altis/f/assignGear/Dodatkowe frakcje/Ultranationalist (indfor)/f_assignGear_aaf.sqf
@@ -408,7 +408,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_grenade,2];
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadegreen,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -425,7 +425,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_grenade,2];
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadegreen,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["ftl"] call _backpack;
@@ -454,7 +454,7 @@ switch (_typeofUnit) do
 		_unit addmagazines [_grenade,2];
 		_unit addmagazines [_pistolmag,3];
 		_unit addweapon _pistol;
-		_unit addmagazines [_smokegrenadeblue,2];
+		_unit addmagazines [_smokegrenadegreen,2];
 		_unit addWeapon "Binocular";
 		_unit linkItem "ItemGPS";
 		["g"] call _backpack;
@@ -927,7 +927,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 1];
 		_unit addMagazineCargoGlobal [_grenade, 4];
 		_unit addMagazineCargoGlobal [_smokegrenade, 4];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 2];
 		_unit addMagazineCargoGlobal [_glmag, 4];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,4];
@@ -949,7 +949,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 12];
 		_unit addmagazineCargoGlobal [_mgrenade,12];
 		_unit addMagazineCargoGlobal [_smokegrenade, 12];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 4];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 4];
 		_unit addMagazineCargoGlobal [_glmag, 12];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 12];
 		_unit addItemCargoGlobal [_firstaid,8];
@@ -971,7 +971,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addmagazineCargoGlobal [_mgrenade,8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 2];
 		_unit addMagazineCargoGlobal [_glmag, 8];
 		_unit addMagazineCargoGlobal [_glsmokewhite, 4];
 		_unit addItemCargoGlobal [_firstaid,6];
@@ -994,7 +994,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 2];
 		_unit addMagazineCargoGlobal [_grenade, 8];
 		_unit addMagazineCargoGlobal [_smokegrenade, 8];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 2];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 2];
 		_unit addItemCargoGlobal [_firstaid, 6];
 };
 
@@ -1015,7 +1015,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 6];
 		_unit addMagazineCargoGlobal [_grenade, 25];
 		_unit addMagazineCargoGlobal [_smokegrenade, 25];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 6];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 6];
 		_unit addItemCargoGlobal [_firstaid, 25];
 };
 
@@ -1036,7 +1036,7 @@ switch (_typeofUnit) do
 		_unit addMagazineCargoGlobal [_ratmag, 20];
 		_unit addMagazineCargoGlobal [_grenade, 75];
 		_unit addMagazineCargoGlobal [_smokegrenade, 75];
-		_unit addMagazineCargoGlobal [_smokegrenadeblue, 20];
+		_unit addMagazineCargoGlobal [_smokegrenadegreen, 20];
 		_unit addItemCargoGlobal [_firstaid, 75];
 };
 

--- a/Szblon_misji.Altis/f/assignGear/f_assignGear_aaf.sqf
+++ b/Szblon_misji.Altis/f/assignGear/f_assignGear_aaf.sqf
@@ -134,8 +134,9 @@ _pistolmag = "rhs_mag_9x18_12_57N181S";
 // Granaty ręczne
 _grenade = "rhs_mag_rgd5";
 _smokegrenade = "SmokeShell";
-_smokegrenadegreen = "rhs_mag_rdg2_black";
-_smokegrenadered = "rhs_mag_nspn_red";
+_smokegrenadegreen = "SmokeShellGreen";
+_smokegrenadered = "SmokeShellRed";
+_smokegrenadeblue = "SmokeShellBlue";
 
 // Sprzet medyczny
 _personalAidKit = "ACE_personalAidKit";		// Zestaw pierwszej pomocy

--- a/Szblon_misji.Altis/f/assignGear/f_assignGear_aaf_b.sqf
+++ b/Szblon_misji.Altis/f/assignGear/f_assignGear_aaf_b.sqf
@@ -299,7 +299,7 @@ case "mmgag":
 	};
 	// LOADOUT: MEDIUM
 	if (_loadout == 1) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARm;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 3];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 3];
@@ -310,7 +310,7 @@ case "mmgag":
 	};
 	// LOADOUT: HEAVY
 	if (_loadout == 2) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARb;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 4];

--- a/Szblon_misji.Altis/f/assignGear/f_assignGear_csat.sqf
+++ b/Szblon_misji.Altis/f/assignGear/f_assignGear_csat.sqf
@@ -134,8 +134,9 @@ _pistolmag = "rhs_mag_9x18_12_57N181S";
 // Granaty ręczne
 _grenade = "rhs_mag_rgd5";
 _smokegrenade = "SmokeShell";
-_smokegrenadegreen = "rhs_mag_rdg2_black";
-_smokegrenadered = "rhs_mag_nspn_red";
+_smokegrenadegreen = "SmokeShellGreen";
+_smokegrenadered = "SmokeShellRed";
+_smokegrenadeblue = "SmokeShellBlue";
 
 // Sprzet medyczny
 _personalAidKit = "ACE_personalAidKit";		// Zestaw pierwszej pomocy

--- a/Szblon_misji.Altis/f/assignGear/f_assignGear_csat_b.sqf
+++ b/Szblon_misji.Altis/f/assignGear/f_assignGear_csat_b.sqf
@@ -296,7 +296,7 @@ case "mmgag":
 	};
 	// LOADOUT: MEDIUM
 	if (_loadout == 1) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARm;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 3];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 3];
@@ -307,7 +307,7 @@ case "mmgag":
 	};
 	// LOADOUT: HEAVY
 	if (_loadout == 2) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARb;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 4];

--- a/Szblon_misji.Altis/f/assignGear/f_assignGear_nato_b.sqf
+++ b/Szblon_misji.Altis/f/assignGear/f_assignGear_nato_b.sqf
@@ -295,7 +295,7 @@ case "mmgag":
 	};
 	// LOADOUT: MEDIUM
 	if (_loadout == 1) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARm;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 3];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 3];
@@ -306,7 +306,7 @@ case "mmgag":
 	};
 	// LOADOUT: HEAVY
 	if (_loadout == 2) then {
-		_unit addBackpack _bagAR;
+		_unit addBackpack _bagARb;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag_tr, 4];

--- a/Szblon_misji.Altis/init.sqf
+++ b/Szblon_misji.Altis/init.sqf
@@ -234,3 +234,8 @@ f_var_cachingAggressiveness = 2;
 // execVM "f\headlessclient\passToHCs.sqf";
 
 // ====================================================================================
+
+//Dodanie zabezpieczenia po respie
+[]  execVM "f\Safezone\safety_init.sqf";
+
+// ====================================================================================


### PR DESCRIPTION
Raport z aktywności:

1. Naprawa plecaka dla obserwatora MMG (nie było deklaracji dla danego plecaka, zostało to poprawione),
2. Dodanie do pliku init brakującej linijki,
3. Dodanie poprawnych komentarzy, aby ułatwić zrozumienie dla nowych MM,
4. Naprawa granatów dymnych (poprawienie i dodanie deklaracji dla wszystkich rodzajów granatów tj. biały,niebieski,czerwony,zielony oraz zamiana ich na podstawowe granaty dymne z army ponieważ te z RHS nie nadawały się poprawnie do wyposażenia, poprawione zostało także odpowiednie nadawanie grantów dla frakcji tj. nato-niebieski, opfor-czerwony, aff-zielony)